### PR TITLE
fix cache write crash (missing _writeCache func)

### DIFF
--- a/lib/FFContextStorage.js
+++ b/lib/FFContextStorage.js
@@ -331,9 +331,7 @@ class FFContextStorage {
             body: jsonData,
             headers: { 'Content-Type': 'application/json;charset=utf-8' }
         }
-        console.debug('writeCache scope ' + scope)
-        const result = await self.client.post(path, opts)
-        console.log('writeCache result', result)
+        await self.client.post(path, opts)
     }
 }
 

--- a/lib/FFContextStorage.js
+++ b/lib/FFContextStorage.js
@@ -8,7 +8,7 @@ const CONFIG_ERROR_MSG = 'Persistent context plugin cannot be used outside of Fl
  * @property {string} projectID - The FlowForge project ID
  * @property {string} token - The FlowForge project token
  * @property {string} [url='http://127.0.0.1:3001'] - The FlowForge File Store URL
- * @property {number} [requestTimeout=1000] - The number of milliseconds to wait before timing out a request
+ * @property {number} [requestTimeout=3000] - The number of milliseconds to wait before timing out a request
  * @property {number} [pageSize=20] - The number of context items/rows to fetch per page
  * @property {number} [flushInterval=30] - The number of seconds to wait before flushing pending writes
  * @property {boolean} [cache=true] - Whether to cache context items in memory (required for synchronous get/set)
@@ -19,7 +19,7 @@ class FFContextStorage {
         // Ensure sane config
         config = config || {}
         config.pageSize = Math.max(1, config.pageSize || 20)
-        config.requestTimeout = Math.max(500, config.requestTimeout || 1000)
+        config.requestTimeout = Math.max(500, config.requestTimeout || 3000)
         config.flushInterval = Math.max(0, config.flushInterval || 30) * 1000
         config.cache = Object.hasOwn(config, 'cache') ? config.cache : true
         config.projectID = config?.projectID || (process.env.FF_FS_TEST_CONFIG ? process.env.FLOWFORGE_PROJECT_ID : null)
@@ -72,7 +72,7 @@ class FFContextStorage {
             responseType: 'json'
         }
         self.nextActiveCursor = null
-        const limit = self.pageSize
+        const limit = self.config.pageSize
         let cursor = null
         let result = await getNext(cursor, limit)
         while (result) {
@@ -120,7 +120,6 @@ class FFContextStorage {
                 } else {
                     delete self.knownCircularRefs[scope]
                 }
-                console.debug('Flushing flowforge persistent context scope ' + scope)
                 promises.push(self._writeCache(scope, stringifiedContext.json))
             })
             delete self._pendingWriteTimeout
@@ -322,6 +321,19 @@ class FFContextStorage {
     _export () {
         // TODO: needed? I think not looking through @node-red/runtime/lib/nodes/context/index.js
         return []
+    }
+
+    async _writeCache (scope, jsonData) {
+        const self = this
+        const path = `cache/${scope}`
+        const opts = {
+            responseType: 'json',
+            body: jsonData,
+            headers: { 'Content-Type': 'application/json;charset=utf-8' }
+        }
+        console.debug('writeCache scope ' + scope)
+        const result = await self.client.post(path, opts)
+        console.log('writeCache result', result)
     }
 }
 


### PR DESCRIPTION
## Description

Fix a node-red crash when cache is flushed.

the function `_writeCache` was completely lost from the code.

I have no idea how this got lost - its a mystery. 

This was not picked up in a test (will raise follow up issue) but in the interest of time, please review & merge this as is.

## Related Issue(s)

#17 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

