### PR TITLE
Prep for NR 3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.0.4",
             "license": "SEE LICENSE in LICENSE",
             "dependencies": {
-                "@node-red/util": "3.0.2",
+                "@node-red/util": "^3.0.2",
                 "got": "11.8.5",
                 "json-stringify-safe": "5.0.1"
             },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dependencies": {
         "got": "11.8.5",
         "json-stringify-safe": "5.0.1",
-        "@node-red/util": "3.0.2"
+        "@node-red/util": "^3.0.2"
     },
     "devDependencies": {
         "@flowforge/file-server": "git://github.com/flowforge/flowforge-file-server.git",


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Allow NR 3.1 version of @node-red/utils to be used which will pull in the new version of moment-timezone.

This allows lots of other deps to update.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

